### PR TITLE
 EC2 instance that automatically creates a new Strapi app

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "5.99.1"
+  hashes = [
+    "h1:967WCGUW/vgrjUMBvC+HCie1DVgOXHwUkhm2ng3twJw=",
+    "zh:00b0a61c6d295300f0aa7a79a7d40e9f836164f1fff816d38324c148cd846887",
+    "zh:1ee9d5ccb67378704642db62113ac6c0d56d69408a9c1afb9a8e14b095fc0733",
+    "zh:2035977ed418dcb18290785c1eeb79b7133b39f718c470346e043ac48887ffc7",
+    "zh:67e3ca1bf7061900f81cf958d5c771a2fd6048c2b185bec7b27978349b173a90",
+    "zh:87fadbe5de7347ede72ad879ff8d8d9334103cd9aa4a321bb086bfac91654944",
+    "zh:901d170c457c2bff244a2282d9de595bdb3ebecc33a2034c5ce8aafbcff66db9",
+    "zh:92c07d6cf530679565b87934f9f98604652d787968cce6a3d24c148479b7e34b",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a7d4803b4c5ff17f029f8b270c91480442ece27cec7922c38548bcfea2ac2d26",
+    "zh:afda848da7993a07d29018ec25ab6feda652e01d4b22721da570ce4fcc005292",
+    "zh:baaf16c98b81bad070e0908f057a97108ecd6e8c9f754d7a79b18df4c8453279",
+    "zh:c3dd496c5014427599d6b6b1c14c7ebb09a15df78918ae0be935e7bfa83b894c",
+    "zh:e2b84c1d40b3f2c4b1d74bf170b9e932983b61bac0e6dab2e36f5057ddcc997f",
+    "zh:e49c92cb29c53b4573ed4d9c946486e6bcfc1b63f1aee0c79cc7626f3d9add03",
+    "zh:efae8e339c4b13f546e0f96c42eb95bf8347de22e941594849b12688574bf380",
+  ]
+}

--- a/hosts
+++ b/hosts
@@ -1,0 +1,2 @@
+[strapi]
+51.21.131.16 ansible_user=ubuntu ansible_ssh_private_key_file=~/.ssh/id_rsa

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,65 @@
+provider "aws" {
+  region = var.region
+}
+
+resource "aws_key_pair" "strapi_key" {
+  key_name   = var.key_name
+  public_key = file(var.public_key_path)
+}
+
+resource "aws_security_group" "strapi_sg" {
+  name        = "strapi-sg"
+  description = "Allow SSH and Strapi ports"
+
+  ingress {
+    from_port   = 1337
+    to_port     = 1337
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_instance" "strapi_ec2" {
+  ami                         = "ami-042b4708b1d05f512"  # Ubuntu 22.04 LTS (eu-north-1)
+  instance_type               = var.instance_type
+  key_name                    = aws_key_pair.strapi_key.key_name
+  vpc_security_group_ids      = [aws_security_group.strapi_sg.id]
+  associate_public_ip_address = true
+
+  # ✅ Bigger disk size
+  root_block_device {
+    volume_size = 20
+    volume_type = "gp2"
+  }
+
+  tags = {
+    Name = "Strapi-Ubuntu"
+  }
+}
+
+output "instance_public_ip" {
+  description = "Public IP of the EC2 instance running Strapi"
+  value       = aws_instance.strapi_ec2.public_ip
+}
+

--- a/main.tf.save
+++ b/main.tf.save
@@ -1,0 +1,53 @@
+provider "aws" {
+  region = var.region
+}
+
+resource "aws_key_pair" "strapi_key" {
+  key_name   = var.key_name
+  public_key = file(var.public_key_path)
+}
+
+resource "aws_security_group" "strapi_sg" {
+  name        = "strapi-sg"
+  description = "Allow SSH and Strapi ports"
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 1337
+    to_port     = 1337
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_instance" "strapi_ec2" {
+  ami                    = "ami-023be33bd68f6c094"
+  instance_type          = var.instance_type
+  key_name               = aws_key_pair.strapi_key.key_name
+  vpc_security_group_ids = [aws_security_group.strapi_sg.id]
+  associate_public_ip_address = true
+
+    
+
+  tags = {
+    Name = "Strapi-Auto"
+  }
+}
+
+output "instance_ip" {
+  value = aws_instance.strapi_ec2.public_ip
+}
+

--- a/main.tf.save.1
+++ b/main.tf.save.1
@@ -1,0 +1,74 @@
+provider "aws" {
+  region = var.region
+}
+
+resource "aws_key_pair" "strapi_key" {
+  key_name   = var.key_name
+  public_key = file(var.public_key_path)
+}
+
+resource "aws_security_group" "strapi_sg" {
+  name        = "strapi-sg"
+  description = "Allow SSH and Strapi ports"
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 1337
+    to_port     = 1337
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_instance" "strapi_ec2" {
+  ami                    = "ami-05fcfb9614772f051"  # Amazon Linux 2023
+  instance_type          = var.instance_type
+  key_name               = aws_key_pair.strapi_key.key_name
+  vpc_security_group_ids = [aws_security_group.strapi_sg.id]
+  associate_public_ip_address = true
+
+  user_data = <<-EOF
+#!/bin/bash
+exec > /var/log/user-data.log 2>&1
+
+# Update system and install dependencies
+yum update -y
+yum install -y gcc-c++ make git curl
+
+# Install Node.js (LTS)
+curl -fsSL https://rpm.nodesource.com/setup_lts.x | bash -
+yum install -y nodejs
+
+# Install Yarn and PM2 globally
+npm install -g yarn pm2
+
+# Set permissions and run setup as ec2-user
+su - ec2-user -c '
+  mkdir -p ~/strapi-app
+  cd ~/strapi-app
+
+  # Create new Strapi app (non
+
+
+  tags = {
+    Name = "Strapi-AmazonLinux"
+  }
+}
+
+output "instance_public_ip" {
+  description = "Public IP of the EC2 instance running Strapi"
+  value       = aws_instance.strapi_ec2.public_ip
+}

--- a/site.yml
+++ b/site.yml
@@ -1,0 +1,90 @@
+- hosts: strapi
+  become: yes
+
+  tasks:
+    - name: Update apt cache
+      apt:
+        update_cache: yes
+
+    - name: Install system dependencies
+      apt:
+        name:
+          - curl
+          - gnupg
+          - build-essential
+          - expect
+        state: present
+
+    - name: Add NodeSource APT repository for Node.js 18.x
+      shell: curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
+      args:
+        executable: /bin/bash
+
+    - name: Install Node.js and npm
+      apt:
+        name:
+          - nodejs
+        state: present
+
+    - name: Install pm2 globally
+      npm:
+        name: pm2
+        global: yes
+
+    - name: Install yarn globally
+      npm:
+        name: yarn
+        global: yes
+
+    # Optional: create expect script for Strapi install (can be enhanced later)
+    - name: Create expect script to bypass Strapi prompts
+      copy:
+        dest: /home/ubuntu/create-strapi.expect
+        owner: ubuntu
+        group: ubuntu
+        mode: '0755'
+        content: |
+          #!/usr/bin/expect -f
+          set timeout -1
+          spawn npx create-strapi-app strapi-app --quickstart --no-run
+          expect {
+            "Ok to proceed? (y)" {
+              send "y\r"
+              exp_continue
+            }
+            "Please log in or sign up*" {
+              send "\033\[B"
+              send "\r"
+              exp_continue
+            }
+            eof
+          }
+
+    - name: Confirm expect script exists
+      stat:
+        path: /home/ubuntu/create-strapi.expect
+      register: expect_script
+
+    - name: Debug path exists
+      debug:
+        msg: "Expect script found: {{ expect_script.stat.exists }}"
+
+    - name: Run Strapi installer
+      become_user: ubuntu
+      shell: /home/ubuntu/create-strapi.expect
+      args:
+        executable: /usr/bin/expect
+
+    - name: Install Strapi dependencies
+      become_user: ubuntu
+      npm:
+        path: /home/ubuntu/strapi-app
+        state: present
+
+    - name: Start Strapi with pm2
+      become_user: ubuntu
+      shell: |
+        pm2 start npm --name strapi -- run dev
+        pm2 save
+      args:
+        chdir: /home/ubuntu/strapi-app

--- a/terraform.tfstate
+++ b/terraform.tfstate
@@ -1,0 +1,263 @@
+{
+  "version": 4,
+  "terraform_version": "1.12.1",
+  "serial": 205,
+  "lineage": "bfe97f04-5581-e2a1-ab22-d6b6b8a091ae",
+  "outputs": {
+    "instance_public_ip": {
+      "value": "51.21.131.16",
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "aws_instance",
+      "name": "strapi_ec2",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "ami": "ami-042b4708b1d05f512",
+            "arn": "arn:aws:ec2:eu-north-1:458854656281:instance/i-05039342ebf697dab",
+            "associate_public_ip_address": true,
+            "availability_zone": "eu-north-1a",
+            "capacity_reservation_specification": [
+              {
+                "capacity_reservation_preference": "open",
+                "capacity_reservation_target": []
+              }
+            ],
+            "cpu_core_count": 1,
+            "cpu_options": [
+              {
+                "amd_sev_snp": "",
+                "core_count": 1,
+                "threads_per_core": 2
+              }
+            ],
+            "cpu_threads_per_core": 2,
+            "credit_specification": [
+              {
+                "cpu_credits": "unlimited"
+              }
+            ],
+            "disable_api_stop": false,
+            "disable_api_termination": false,
+            "ebs_block_device": [],
+            "ebs_optimized": false,
+            "enable_primary_ipv6": null,
+            "enclave_options": [
+              {
+                "enabled": false
+              }
+            ],
+            "ephemeral_block_device": [],
+            "get_password_data": false,
+            "hibernation": false,
+            "host_id": "",
+            "host_resource_group_arn": null,
+            "iam_instance_profile": "",
+            "id": "i-05039342ebf697dab",
+            "instance_initiated_shutdown_behavior": "stop",
+            "instance_lifecycle": "",
+            "instance_market_options": [],
+            "instance_state": "running",
+            "instance_type": "t3.medium",
+            "ipv6_address_count": 0,
+            "ipv6_addresses": [],
+            "key_name": "strapi-key",
+            "launch_template": [],
+            "maintenance_options": [
+              {
+                "auto_recovery": "default"
+              }
+            ],
+            "metadata_options": [
+              {
+                "http_endpoint": "enabled",
+                "http_protocol_ipv6": "disabled",
+                "http_put_response_hop_limit": 2,
+                "http_tokens": "required",
+                "instance_metadata_tags": "disabled"
+              }
+            ],
+            "monitoring": false,
+            "network_interface": [],
+            "outpost_arn": "",
+            "password_data": "",
+            "placement_group": "",
+            "placement_partition_number": 0,
+            "primary_network_interface_id": "eni-0cfedb1efa88c2a42",
+            "private_dns": "ip-172-31-26-218.eu-north-1.compute.internal",
+            "private_dns_name_options": [
+              {
+                "enable_resource_name_dns_a_record": false,
+                "enable_resource_name_dns_aaaa_record": false,
+                "hostname_type": "ip-name"
+              }
+            ],
+            "private_ip": "172.31.26.218",
+            "public_dns": "ec2-51-21-131-16.eu-north-1.compute.amazonaws.com",
+            "public_ip": "51.21.131.16",
+            "root_block_device": [
+              {
+                "delete_on_termination": true,
+                "device_name": "/dev/sda1",
+                "encrypted": false,
+                "iops": 100,
+                "kms_key_id": "",
+                "tags": null,
+                "tags_all": {},
+                "throughput": 0,
+                "volume_id": "vol-0f2f9857301e471f3",
+                "volume_size": 20,
+                "volume_type": "gp2"
+              }
+            ],
+            "secondary_private_ips": [],
+            "security_groups": [
+              "strapi-sg"
+            ],
+            "source_dest_check": true,
+            "spot_instance_request_id": "",
+            "subnet_id": "subnet-0f21371ecc142b78b",
+            "tags": {
+              "Name": "Strapi-Ubuntu"
+            },
+            "tags_all": {
+              "Name": "Strapi-Ubuntu"
+            },
+            "tenancy": "default",
+            "timeouts": null,
+            "user_data": null,
+            "user_data_base64": null,
+            "user_data_replace_on_change": false,
+            "volume_tags": null,
+            "vpc_security_group_ids": [
+              "sg-0fffcaf8bfc32a003"
+            ]
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6MTIwMDAwMDAwMDAwMCwicmVhZCI6OTAwMDAwMDAwMDAwLCJ1cGRhdGUiOjYwMDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiMSJ9",
+          "dependencies": [
+            "aws_key_pair.strapi_key",
+            "aws_security_group.strapi_sg"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_key_pair",
+      "name": "strapi_key",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "arn": "arn:aws:ec2:eu-north-1:458854656281:key-pair/strapi-key",
+            "fingerprint": "73:f5:e7:b7:1a:f1:b9:73:b4:5e:a6:fe:65:7d:32:7e",
+            "id": "strapi-key",
+            "key_name": "strapi-key",
+            "key_name_prefix": "",
+            "key_pair_id": "key-05daed2b2c46f73ae",
+            "key_type": "rsa",
+            "public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn1cNvf3LYEW2i/xMCaBDJMLaB3GHyE9JhtpuD26xD6XXIu4QzVYO2MQBJbQ+qq+G4J6goP1TK743vypCNsXna1Pt+mPMPOJrbHdWjL2R4SKnSZmHR6MrxxLB4ohLYDT3g78vcsxapFmolTc9lfZ5A1D5Nl7zS2WdK3tKCmdkL7mprjq/ZzdEsHyR/ZJujFC+XL8RywilXpE0ePPcFgv3b1gl8viwwOgnA9XrdYO2tVLuYskjbWY8ZvnlW58Fh/0oOU/ptcKESBvJoLvR2gJ/L+nAzi50ntWoee8Chs4BGk7IPCE+fS0WIXJ0UFSm4zqm4yx7peVncNgYhHkg015Df ubuntu@ip-172-31-17-252",
+            "tags": null,
+            "tags_all": {}
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_security_group",
+      "name": "strapi_sg",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "arn": "arn:aws:ec2:eu-north-1:458854656281:security-group/sg-0fffcaf8bfc32a003",
+            "description": "Allow SSH and Strapi ports",
+            "egress": [
+              {
+                "cidr_blocks": [
+                  "0.0.0.0/0"
+                ],
+                "description": "",
+                "from_port": 0,
+                "ipv6_cidr_blocks": [],
+                "prefix_list_ids": [],
+                "protocol": "-1",
+                "security_groups": [],
+                "self": false,
+                "to_port": 0
+              }
+            ],
+            "id": "sg-0fffcaf8bfc32a003",
+            "ingress": [
+              {
+                "cidr_blocks": [
+                  "0.0.0.0/0"
+                ],
+                "description": "",
+                "from_port": 1337,
+                "ipv6_cidr_blocks": [],
+                "prefix_list_ids": [],
+                "protocol": "tcp",
+                "security_groups": [],
+                "self": false,
+                "to_port": 1337
+              },
+              {
+                "cidr_blocks": [
+                  "0.0.0.0/0"
+                ],
+                "description": "",
+                "from_port": 22,
+                "ipv6_cidr_blocks": [],
+                "prefix_list_ids": [],
+                "protocol": "tcp",
+                "security_groups": [],
+                "self": false,
+                "to_port": 22
+              },
+              {
+                "cidr_blocks": [
+                  "0.0.0.0/0"
+                ],
+                "description": "",
+                "from_port": 80,
+                "ipv6_cidr_blocks": [],
+                "prefix_list_ids": [],
+                "protocol": "tcp",
+                "security_groups": [],
+                "self": false,
+                "to_port": 80
+              }
+            ],
+            "name": "strapi-sg",
+            "name_prefix": "",
+            "owner_id": "458854656281",
+            "revoke_rules_on_delete": false,
+            "tags": null,
+            "tags_all": {},
+            "timeouts": null,
+            "vpc_id": "vpc-021a88cb726fcd82b"
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6OTAwMDAwMDAwMDAwfSwic2NoZW1hX3ZlcnNpb24iOiIxIn0="
+        }
+      ]
+    }
+  ],
+  "check_results": null
+}

--- a/terraform.tfstate.backup
+++ b/terraform.tfstate.backup
@@ -1,0 +1,9 @@
+{
+  "version": 4,
+  "terraform_version": "1.12.1",
+  "serial": 201,
+  "lineage": "bfe97f04-5581-e2a1-ab22-d6b6b8a091ae",
+  "outputs": {},
+  "resources": [],
+  "check_results": null
+}

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -1,0 +1,6 @@
+region            = "eu-north-1"
+key_name          = "strapi-key"
+public_key_path   = "/home/ubuntu/.ssh/id_rsa.pub"
+instance_type     = "t3.medium"
+
+

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,20 @@
+variable "region" {
+  description = "AWS region"
+  default     = "eu-north-1"
+}
+
+variable "instance_type" {
+  description = "EC2 instance type"
+  default     = "t3.medium"
+}
+
+variable "key_name" {
+  description = "Name of the existing EC2 Key Pair"
+  type        = string
+}
+
+variable "public_key_path" {
+  description = "Path to your SSH public key"
+  type        = string
+  default     = "~/.ssh/id_rsa.pub"
+}


### PR DESCRIPTION
Use Terraform to provision an EC2 instance that automatically creates a new Strapi app, installs dependencies, and starts the server — all without any manual commands.